### PR TITLE
Use humanize lib to improve timeout and message deletion logging.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+humanize==4.2.3
 matplotlib==3.1.0
 numpy==1.22.1


### PR DESCRIPTION
Hopefully this provides more context for messages that might have been sent accidentally! 💜

## Before:
![image](https://user-images.githubusercontent.com/95021853/174465798-ad4f93f8-dec8-47d1-89f5-185113a92f0b.png)

## After:
![image](https://user-images.githubusercontent.com/95021853/174465868-e0597ca4-4969-4dcd-8bb0-cce4dfc9626b.png)
