### PR TITLE
add ability to forward user dms to threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ config.json
 *.swp
 *.code-workspace
 **/.devcontainer/*
+.idea
 
 # Other junk
 .DS_Store

--- a/src/config.py
+++ b/src/config.py
@@ -44,3 +44,7 @@ DEBUG_BOT = (cfg['debug'].upper() == "TRUE")
 
 USER_PLOT = "./private/user_plot.png"
 MONTH_PLOT = "./private/month_plot.png"
+
+# bool: whether to create and forward user dms to per-user threads under the mailbox channel
+#       instead of posting messages to directly to the mailbox channel
+FORWARDING_CREATE_THREADS = cfg['messageForwarding']['createThreads']

--- a/src/config.py
+++ b/src/config.py
@@ -48,3 +48,7 @@ MONTH_PLOT = "./private/month_plot.png"
 # bool: whether to create and forward user dms to per-user threads under the mailbox channel
 #       instead of posting messages to directly to the mailbox channel
 FORWARDING_CREATE_THREADS = cfg['messageForwarding']['createThreads']
+
+# list of int: the ids of roles to invite to new forwarded threads
+#              each role must have less than 100 members for the addition to work
+THREAD_ROLES = cfg['messageForwarding']['rolesToAddToThreads']

--- a/src/forwarder.py
+++ b/src/forwarder.py
@@ -1,0 +1,243 @@
+import discord
+from client import client
+import db
+from waiting import AnsweringMachineEntry, is_in_home_server
+import commands
+import commonbot
+from collections import OrderedDict
+from threading import Lock
+
+
+class MessageForwarder:
+    """
+    Handles message forwarding between bouncer DMs and server staff.
+
+    There are two key parts of this functionality:
+     - Bouncer receives DM -> forward it to staff
+     - Staff replies to forwarded message -> reply to user in DMS
+
+    The first part is here. For the second part, the reply command handles figuring out who to message and sending the message.
+
+    We could move reply command functionality into this class, but I left it as is.
+    """
+    def __init__(self, create_threads: bool, mailbox_channel: int, ban_appeal_channel: int, home_server: int):
+        """
+        Creates a new message forwarder.
+
+        :param create_threads: Whether to forward messages into threads or not.
+                               If true, threads are created under either the mailbox/ban appeal channel as appropriate.
+                               If false, messages are sent directly to either the mailbox/ban appeal channel as appropriate.
+        :param mailbox_channel: The channel to forward regular DMs to.
+        :param ban_appeal_channel: The channel to forward ban appeal DMs to.
+        :param home_server: Bouncer's home server, used to make thread names nice.
+        """
+        # Configuration
+        self._create_threads = create_threads
+        self._mailbox_channel = mailbox_channel
+        self._ban_appeal_channel = ban_appeal_channel
+        self._home_server = home_server
+
+        # Maps user ids to reply thread ids - used when receiving a DM to know which thread to forward it to (if create_threads is true)
+        self._user_id_to_thread_id = LRUCache(lambda user_id: db.get_user_reply_thread_id(user_id), maxsize=50)
+
+        # Maps user reply thread ids to user ids - used when staff replies in a thread to know which user to send the reply to (this will work for existing threads even if create_threads is false)
+        self._thread_id_to_user_id = LRUCache(lambda thread_id: db.get_user_reply_thread_user_id(thread_id), maxsize=50)
+
+        # Both of the above use an LRU cache wrapper around accessing the DB so that every DM/reply does not trigger DB access
+        # The chosen cache size should be equal to the number of concurrent/active conversations we expect users to have with bouncer
+
+    async def on_dm(self, message: discord.Message):
+        """
+        On a DM, forward the message to staff.
+
+        :param message: The message that was sent.
+        """
+        # Ignore blocked users
+        if commands.bu.is_in_blocklist(message.author.id):
+            return
+
+        # Figure out what message to send, which channel to send in, etc based on which server the sender is in
+        if is_in_home_server(message.author):  # If the user is in the home server, treat it as a regular DM
+            reply_message = f"<@{message.author.id}>"
+            answering_machine = commands.reply_am
+            reply_channel = client.get_channel(self._mailbox_channel)
+        else:  # Otherwise, assume it's a ban appeal (users must have a mutual server to message bouncer, they should only be able to join those two)
+            reply_message = f"{str(message.author)} ({message.author.id})"  # Can't ping user, so show username details
+            answering_machine = commands.ban_am
+            reply_channel = client.get_channel(self._ban_appeal_channel)
+
+        # Set latest received reply so '^' works when sending the reply command
+        answering_machine.set_recent_reply(message.author)
+
+        # Fill in the rest of the message with what the user said
+        content = commonbot.utils.combine_message(message)
+        reply_message += f": {content}"
+
+        # If forwarded messages should be grouped into threads, get or create the appropriate thread for the message user
+        if self._create_threads:
+            reply_channel = await self._get_or_create_user_reply_thread(message.author, reply_channel)
+
+        # Forward the message to the channel/thread
+        log_mes = await commonbot.utils.send_message(reply_message, reply_channel)
+
+        try:
+            # Send the user a message so they know something actually happened
+            await message.channel.send("Your message has been forwarded!")
+        except discord.errors.Forbidden as err:
+            if err.code == 50007:
+                await reply_channel.send("Unable to send message forward notification to the above user - Can't send messages to that user")
+            else:
+                await reply_channel.send(f"ERROR: While attempting to send message forward notification, there was an unexpected error. Tell aquova this: {err}")
+
+        # Record that the user is waiting for a reply
+        mes_entry = AnsweringMachineEntry(f"{str(message.author)}", message.created_at, content, log_mes.jump_url)
+        answering_machine.update_entry(message.author.id, mes_entry)
+
+    def get_userid_for_user_reply_thread(self, message: discord.Message) -> int | None:
+        """
+        Get the user id to reply to if message was sent in a reply thread.
+
+        :param message: The staff reply message.
+        :return: The user id, if message was sent in a user reply thread. None otherwise.
+        """
+        return self._thread_id_to_user_id(message.channel.id)
+
+    async def _get_or_create_user_reply_thread(self, user: discord.User, parent_channel: discord.TextChannel) -> discord.Thread:
+        """
+        Either retrieves the existing reply thread for a user, or creates a new one if they don't have one.
+
+        :param user: The user to get or create the reply thread for.
+        :param parent_channel: The parent channel to create the reply thread in, if a new one is needed.
+        :return: The existing/new thread.
+        """
+        thread_id = self._user_id_to_thread_id(user.id)
+
+        if thread_id is None:
+            # This is a first time user messaging bouncer -> create a reply thread for them
+            return await self._create_reply_thread(user, parent_channel)
+
+        # Get thread from thread cache (holds active threads only)
+        user_reply_thread = client.get_channel(thread_id)
+        if user_reply_thread is not None:
+            # Active thread -> update it and use it for the conversation
+            await self._update_reply_thread(user, user_reply_thread)
+            return user_reply_thread
+
+        # The thread is either archived or deleted; use fetch channel to find out which
+        # The order is important: fetch channel is an API call, so we want to avoid it if possible
+        try:
+            user_reply_thread = await client.fetch_channel(thread_id)
+
+            # It was archived -> send a message to notify mods someone is starting a new conversation
+            await parent_channel.send(f"User <@{user.id}> sent bouncer a new message (their reply thread has been un-archived), thread link: <#{thread_id}>.")
+            await self._update_reply_thread(user, user_reply_thread)
+            return user_reply_thread
+        except discord.errors.NotFound:
+            # It was deleted
+            await parent_channel.send(f"Reply thread for user <@{user.id}> was not found (it was probably deleted), creating a new one.")
+            return await self._create_reply_thread(user, parent_channel)
+
+    async def _create_reply_thread(self, user: discord.User, parent_channel: discord.TextChannel) -> discord.Thread:
+        """
+        Creates a reply thread for a user.
+
+        :param user: The user to crate the reply thread for.
+        :param parent_channel: The channel to create the thread in.
+        :return: The new thread.
+        """
+        thread = await parent_channel.create_thread(name=self._user_reply_thread_name(user), type=discord.ChannelType.public_thread)
+
+        # Update DB and caches
+        db.set_user_reply_thread(user.id, thread.id)
+        self._user_id_to_thread_id.set(thread.id, user.id)
+        self._thread_id_to_user_id.set(user.id, thread.id)
+
+        return thread
+
+    async def _update_reply_thread(self, user: discord.User, thread: discord.Thread):
+        """
+        Update a reply thread for a user. That means:
+          - change the thread name to match the user's current name
+          - un-archive it
+
+        :param user: The user the thread is for.
+        :param thread: The thread.
+        """
+        thread_name = self._user_reply_thread_name(user)
+
+        if thread.name != thread_name or thread.archived:
+            await thread.edit(name=thread_name, archived=False)
+
+    def _user_reply_thread_name(self, user: discord.User) -> str:
+        """
+        Returns the name of a user reply thread for a user.
+
+        :param user: The user to create the thread name for.
+        :return: The thread name.
+        """
+        # Try to get their SDV nickname (will be None if they're not in the SDV server, or not in the member cache) for a nicer thread name
+        member = client.get_guild(self._home_server).get_member(user.id)
+        if member is not None:
+            return f"{member.display_name} ({str(user)}) ({user.id})"
+
+        # If that didn't work, use their non-SDV name
+        return f"{str(user)} ({user.id})"
+
+
+class LRUCache:
+    """
+    A custom LRU cache (https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)).
+    Differs from stdlib's functools.lru_cache in that it allows bypassing func to set values directly.
+
+    Based on this comment: https://bugs.python.org/issue28178#msg276812.
+    """
+    def __init__(self, func, maxsize=128):
+        """
+        Creates a new instance.
+
+        :param func: The function to call to get the value for a key if not present in the cache.
+        :param maxsize: The maximum number of items to hold before evicting entries.
+        """
+        self._cache = OrderedDict()
+        self._lock = Lock()
+        self._func = func
+        self._maxsize = maxsize
+
+    def __call__(self, *args):
+        """
+        Retrieve the value for the given key (args).
+
+        :param args: The key.
+        :return:
+        """
+        with self._lock:
+            # If in cache: set entry as recently used, and return it
+            if args in self._cache:
+                self._cache.move_to_end(args)
+                return self._cache[args]
+
+            # Not in cache: call function to get result, store in cache (this also sets the entry as recently used)
+            result = self._func(*args)
+            self._cache[args] = result
+
+            # Evict the oldest entry if reached max cache size
+            if len(self._cache) > self._maxsize:
+                self._cache.popitem(last=False)
+
+            return result
+
+    def set(self, result, *args):
+        """
+        Set the result for given args, bypassing func.
+
+        :param result: The result value.
+        :param args: The args that would be provided to func.
+        """
+        with self._lock:
+            self._cache[args] = result
+            self._cache.move_to_end(args)
+            if len(self._cache) > self._maxsize:
+                self._cache.popitem(last=False)
+
+    def debug_print(self):
+        print(self._cache)

--- a/src/main.py
+++ b/src/main.py
@@ -10,20 +10,24 @@ import commonbot.utils
 from commonbot.debug import Debug
 from commonbot.timekeep import Timekeeper
 
+# Needs to happen before other imports that cause db to be queried
+import db
+db.initialize()
+
 import commands
 import config
-import db
 import visualize
 from client import client
 from config import LogTypes, USERID_LOG_PATH
 from waiting import AnsweringMachineEntry, is_in_home_server
 from watcher import Watcher
+from forwarder import MessageForwarder
 
 # Initialize helper classes
-db.initialize()
 dbg = Debug(config.OWNER, config.CMD_PREFIX, config.DEBUG_BOT)
 tk = Timekeeper()
 watch = Watcher()
+frwrdr = MessageForwarder(config.FORWARDING_CREATE_THREADS, config.MAILBOX, config.BAN_APPEAL, config.HOME_SERVER)
 
 FUNC_DICT = {
     "ban":         [commands.log_user,             LogTypes.BAN],
@@ -36,7 +40,7 @@ FUNC_DICT = {
     "note":        [commands.log_user,             LogTypes.NOTE],
     "preview":     [commands.preview,              None],
     "remove":      [commands.remove_error,         False],
-    "reply":       [commands.reply,                None],
+    "reply":       [commands.reply,                frwrdr],
     "say":         [commands.say,                  None],
     "scam":        [commands.log_user,             LogTypes.SCAM],
     "search":      [commands.search_command,       None],
@@ -339,36 +343,9 @@ async def on_message(message: discord.Message):
         if dbg.should_ignore_message(message):
             return
 
-        # If bouncer detects a private DM sent to it
+        # If bouncer detects a private DM sent to it, forward it to staff
         if isinstance(message.channel, discord.channel.DMChannel):
-            content = commonbot.utils.combine_message(message)
-            # If not blocked, send message along to specified mod channel
-            if not commands.bu.is_in_blocklist(message.author.id):
-                mes = ""
-                chan = None
-                is_home = is_in_home_server(message.author)
-                # If we share the main server, treat that as a DM
-                if is_home:
-                    commands.reply_am.set_recent_reply(message.author)
-                    mes = f"<@{message.author.id}>: {content}"
-                    chan = client.get_channel(config.MAILBOX)
-                # The only other server we should share is the ban appeal server
-                else:
-                    commands.ban_am.set_recent_reply(message.author)
-                    mes = f"{str(message.author)} ({message.author.id}): {content}"
-                    chan = client.get_channel(config.BAN_APPEAL)
-
-                log_mes = await commonbot.utils.send_message(mes, chan)
-
-                # Send them a message so they know something actually happened
-                await message.channel.send("Your message has been forwarded!")
-
-                # Lets also add/update them in answering machine
-                mes_entry = AnsweringMachineEntry(f"{str(message.author)}", message.created_at, content, log_mes.jump_url)
-                if is_home:
-                    commands.reply_am.update_entry(message.author.id, mes_entry)
-                else:
-                    commands.ban_am.update_entry(message.author.id, mes_entry)
+            await frwrdr.on_dm(message)
             return
 
         # Check if user is on watchlist, and should be tracked

--- a/src/main.py
+++ b/src/main.py
@@ -27,7 +27,7 @@ from forwarder import MessageForwarder
 dbg = Debug(config.OWNER, config.CMD_PREFIX, config.DEBUG_BOT)
 tk = Timekeeper()
 watch = Watcher()
-frwrdr = MessageForwarder(config.FORWARDING_CREATE_THREADS, config.MAILBOX, config.BAN_APPEAL, config.HOME_SERVER)
+frwrdr = MessageForwarder(config.FORWARDING_CREATE_THREADS, config.MAILBOX, config.BAN_APPEAL, config.HOME_SERVER, config.THREAD_ROLES)
 
 FUNC_DICT = {
     "ban":         [commands.log_user,             LogTypes.BAN],


### PR DESCRIPTION
## Screenshots

Bouncer can now forward user DMs to threads, rather than posting directly to mailbox!

A user sending a DM:
![image](https://user-images.githubusercontent.com/21993469/211182791-1e145ce5-dac3-4e09-90b3-8cb88d08183f.png)

Bouncer creating a thread:
![image](https://user-images.githubusercontent.com/21993469/211182802-4ff437e8-bbdc-4b94-8c20-bb6429eb14b2.png)
![image](https://user-images.githubusercontent.com/21993469/211182799-643afc8f-cde9-43da-92d6-26277dab9b2c.png)

Staff sending a reply:
![image](https://user-images.githubusercontent.com/21993469/211182812-471a4308-fbd9-4165-b4cf-8f9781d3ab27.png)

A user getting the reply:
![image](https://user-images.githubusercontent.com/21993469/211182831-85bcc97b-4c4e-4613-b4cd-a18efa878a16.png)

## Summary

This behavior is controlled by a config option.

If enabled:
 * When a user messages bouncer:
   * If they do not yet have a thread created for them, a thread will be created under the mailbox channel for them. This is called a 'reply thread'.
   * Their messages will be forwarded to the thread for them rather than directly in mailbox.
 * When staff replies to user messages in reply threads, they don't need to mention a user. Bouncer will use the user the thread is for.
   * If they do mention a user, they'll get an error because reply threads are for a specific user.
 * When staff replies to user messages in or outside a reply thread, `^` functionality is disabled to avoid confusion.
   * It's not needed in threads, and outside threads, it wouldn't be clear who it's replying to.

If the user/staff doesn't reply in a while, threads will be auto-archived. New messages will un-archive the thread. If a thread for a user is deleted, a new one will be created when they send a message.

If disabled:
* When a new user messages bouncer, it'll go directly to mailbox.
* When staff replies to user messages in or outside a reply thread, `^` works as before.
* When staff replies to old user messages in any existing reply threads (before the setting was disabled), they still won't need to mention a user. Bouncer will still forward messages in threads to the user the thread is for.

In other words, when disabled the functionality is equivalent to existing behavior except that reply threads not needing mentions keeps working for convenience.

Once any issues/staff requests are added and people think this approach is better, we can remove the old non-thread functionality.

## Testing

Did some manual query explanation and the unique index on the `userReplyThreads` table is used as expected.

Also, a bunch of manual testing in the test server. Looks like everything works, but there might be some trouble given the much larger volume of DMs staff gets.

I'll be available to iron out issues. If there are problems, or staff doesn't like the new behavior, it can be disabled through the config option.

## Not included

This is a relatively big change, so it doesn't include some other features I thought of. Namely:
 * Adding all staff to every thread automatically. We could do this if staff miss messages in threads they don't join.

## Implementation details

### Storage
Two integers are now stored in a new DB table for every user messaging bouncer.

I don't expect that to be a problem in terms of storage space. Napkin math: to store info for every single member of the server today (~160K users), it'd take 3 MB (excluding the index and other bookkeeping). That's pretty small.

I looked into an approach that stores the user id in the thread name itself, so that bouncer wouldn't have to store anything, but it doesn't work well because the discord API doesn't allow easily retrieving threads by their names (only by their snowflake ids).

### Forwarding user DMs

The first part of the implementation is handling the case where users message bouncer so that messages go to threads rather than the mailbox. This ended up being a bunch of code, so I created a new `MessageForwarder` class that takes care of those details. It's invoked in the `on_message` in main.py.

### Staff replying to forwarded messages

The second part of the implementation is handling the case where staff replies to a message so that bouncer knows which user to reply to in a reply thread. This is done by modifying the `reply` function in commands.py.

## Required config additions

Add this to the config.json to enable threads (set to `false`) to use previous behavior.

This setting needs a re-start to apply.

```js
  "messageForwarding": {
    "createThreads": true
  }
```

---

As always, let me know if you'd like any changes or a different approach!