### PR TITLE
Remove legacy DM handling code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A Discord moderator bot, designed to be used with the Stardew Valley server
 
-Written by aquova, et. al, 2018-2022
+Written by aquova, et. al, 2018-2023
 
-https://github.com/StardewValleyDiscord/bouncer
+https://github.com/aquova/bouncer
 
 https://discord.gg/stardewvalley
 

--- a/src/config.py
+++ b/src/config.py
@@ -34,7 +34,6 @@ MAILBOX = cfg['channels']['mailbox']
 LOG_CHAN = cfg['channels']['log']
 SYS_LOG = cfg['channels']['syslog']
 WATCHLIST_CHAN = cfg['channels']['watchlist']
-BAN_APPEAL = cfg['channels']['ban_appeal']
 
 VALID_ROLES = cfg['roles']['admin']
 
@@ -44,10 +43,6 @@ DEBUG_BOT = (cfg['debug'].upper() == "TRUE")
 
 USER_PLOT = "./private/user_plot.png"
 MONTH_PLOT = "./private/month_plot.png"
-
-# bool: whether to create and forward user dms to per-user threads under the mailbox channel
-#       instead of posting messages to directly to the mailbox channel
-FORWARDING_CREATE_THREADS = cfg['messageForwarding']['createThreads']
 
 # list of int: the ids of roles to invite to new forwarded threads
 #              each role must have less than 100 members for the addition to work

--- a/src/forwarder.py
+++ b/src/forwarder.py
@@ -60,8 +60,6 @@ class MessageForwarder:
         # Otherwise they can't, so we show username details instead
         reply_message = f"<@{message.author.id}>" if not is_ban_appeal else f"{str(message.author)} ({message.author.id})"
 
-        # Default to sending messages to mailbox
-        answering_machine = commands.am
         reply_channel = client.get_channel(self._mailbox_channel)
 
         # Handle ban appeals
@@ -89,7 +87,7 @@ class MessageForwarder:
 
         # Record that the user is waiting for a reply
         mes_entry = AnsweringMachineEntry(f"{str(message.author)}", message.created_at, content, log_mes.jump_url)
-        answering_machine.update_entry(message.author.id, mes_entry)
+        commands.am.update_entry(message.author.id, mes_entry)
 
     def get_userid_for_user_reply_thread(self, message: discord.Message) -> int | None:
         """
@@ -194,10 +192,10 @@ class MessageForwarder:
         # Try to get their SDV nickname (will be None if they're not in the SDV server, or not in the member cache) for a nicer thread name
         member = client.get_guild(self._home_server).get_member(user.id)
         if member is not None:
-            return f"{member.display_name} ({str(user)}) ({user.id})"
+            return f"{member.display_name} ({str(user)})"
 
         # If that didn't work, use their non-SDV name
-        return f"{str(user)} ({user.id})"
+        return f"{str(user)}"
 
 
 class LRUCache:

--- a/src/forwarder.py
+++ b/src/forwarder.py
@@ -20,29 +20,23 @@ class MessageForwarder:
 
     We could move reply command functionality into this class, but I left it as is.
     """
-    def __init__(self, create_threads: bool, mailbox_channel: int, ban_appeal_channel: int, home_server: int, staff_roles: list[int]):
+    def __init__(self, mailbox_channel: int, home_server: int, staff_roles: list[int]):
         """
         Creates a new message forwarder.
 
-        :param create_threads: Whether to forward messages into threads or not.
-                               If true, threads are created under the mailbox channel.
-                               If false, messages are sent directly to either the mailbox/ban appeal channel as appropriate.
         :param mailbox_channel: The channel to forward regular DMs to.
-        :param ban_appeal_channel: The channel to forward ban appeal DMs to. Used only if threads are disabled.
         :param home_server: Bouncer's home server, used to make thread names nice.
         :param staff_roles: The roles containing members to add to created threads.
         """
         # Configuration
-        self._create_threads = create_threads
         self._mailbox_channel = mailbox_channel
-        self._ban_appeal_channel = ban_appeal_channel
         self._home_server = home_server
         self._staff_roles = staff_roles
 
-        # Maps user ids to reply thread ids - used when receiving a DM to know which thread to forward it to (if create_threads is true)
+        # Maps user ids to reply thread ids - used when receiving a DM to know which thread to forward it to
         self._user_id_to_thread_id = LRUCache(lambda user_id: db.get_user_reply_thread_id(user_id), maxsize=50)
 
-        # Maps user reply thread ids to user ids - used when staff replies in a thread to know which user to send the reply to (this will work for existing threads even if create_threads is false)
+        # Maps user reply thread ids to user ids - used when staff replies in a thread to know which user to send the reply to
         self._thread_id_to_user_id = LRUCache(lambda thread_id: db.get_user_reply_thread_user_id(thread_id), maxsize=50)
 
         # Both of the above use an LRU cache wrapper around accessing the DB so that every DM/reply does not trigger DB access
@@ -67,29 +61,19 @@ class MessageForwarder:
         reply_message = f"<@{message.author.id}>" if not is_ban_appeal else f"{str(message.author)} ({message.author.id})"
 
         # Default to sending messages to mailbox
-        answering_machine = commands.reply_am
+        answering_machine = commands.am
         reply_channel = client.get_channel(self._mailbox_channel)
 
         # Handle ban appeals
         if is_ban_appeal:
-            if self._create_threads:
-                # If threads are on, add an extra disambiguator to the message but still send everything to mailbox
-                reply_message += " (banned)"
-            else:
-                # If threads are off, send to the ban appeal channel instead
-                answering_machine = commands.ban_am
-                reply_channel = client.get_channel(self._ban_appeal_channel)
-
-        # Set latest received reply so '^' works when sending the reply command
-        answering_machine.set_recent_reply(message.author)
+            reply_message += " (banned)"
 
         # Fill in the rest of the message with what the user said
         content = commonbot.utils.combine_message(message)
         reply_message += f": {content}"
 
-        # If forwarded messages should be grouped into threads, get or create the appropriate thread for the message user
-        if self._create_threads:
-            reply_channel = await self._get_or_create_user_reply_thread(message.author, reply_channel)
+        # Get or create the appropriate thread for the message user
+        reply_channel = await self._get_or_create_user_reply_thread(message.author, reply_channel)
 
         # Forward the message to the channel/thread
         log_mes = await commonbot.utils.send_message(reply_message, reply_channel)

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 # Bouncer
-# https://github.com/StardewValleyDiscord/bouncer
+# https://github.com/aquova/bouncer
 
 from datetime import datetime, timezone
 
@@ -27,7 +27,7 @@ from forwarder import MessageForwarder
 dbg = Debug(config.OWNER, config.CMD_PREFIX, config.DEBUG_BOT)
 tk = Timekeeper()
 watch = Watcher()
-frwrdr = MessageForwarder(config.FORWARDING_CREATE_THREADS, config.MAILBOX, config.BAN_APPEAL, config.HOME_SERVER, config.THREAD_ROLES)
+frwrdr = MessageForwarder(config.MAILBOX, config.HOME_SERVER, config.THREAD_ROLES)
 
 FUNC_DICT = {
     "ban":         [commands.log_user,             LogTypes.BAN],
@@ -187,8 +187,7 @@ async def on_member_ban(server: discord.Guild, member: discord.Member):
         return
 
     # We can remove banned user from our answering machine and watch list (if they exist)
-    commands.reply_am.remove_entry(member.id)
-    commands.ban_am.remove_entry(member.id)
+    commands.am.remove_entry(member.id)
     watch.remove_user(member.id)
 
     # Keep a record of their banning, in case the log is made after they're no longer here
@@ -209,8 +208,7 @@ async def on_member_remove(member: discord.Member):
         return
 
     # We can remove left users from our answering machine
-    commands.reply_am.remove_entry(member.id)
-    commands.ban_am.remove_entry(member.id)
+    commands.am.remove_entry(member.id)
 
     # Remember that the user has left, in case we want to log after they're gone
     username = f"{str(member)}"

--- a/src/waiting.py
+++ b/src/waiting.py
@@ -18,16 +18,6 @@ class AnsweringMachineEntry:
 class AnsweringMachine:
     def __init__(self):
         self.waiting_list = {}
-        self.recent_reply = None
-
-    def set_recent_reply(self, user: discord.Member):
-        self.recent_reply = user
-
-    def get_recent_reply(self) -> Optional[discord.Member]:
-        return self.recent_reply
-
-    def recent_reply_exists(self) -> bool:
-        return self.recent_reply is not None
 
     def remove_entry(self, user_id: int):
         if user_id in self.waiting_list:


### PR DESCRIPTION
Removes the old legacy DM handling code, in favor of the new thread-based system. This commit should change no functionality from when the 'createThreads' flag is set to true, as has been the case on the production instance for a while now.

For reference, the removal of the legacy DM method does impact several other systems:

- We no longer need to know the ID of the ban appeal server
- There is now only one AnsweringMachine instance
- '$reply ^' is no longer functional