### PR TITLE
Search: use reply thread user if in reply thread

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -97,11 +97,18 @@ User Search
 
 Searches the database for the specified user, given a message
 """
-async def search_command(mes: discord.Message, _):
+async def search_command(mes: discord.Message, message_forwarder: MessageForwarder):
+    # First check mention
     userid = ul.parse_id(mes)
     if not userid:
-        await mes.channel.send(f"I wasn't able to find a user anywhere based on that message. `{CMD_PREFIX}search USER`")
-        return
+        # If no mention, check if it's a reply thread
+        thread_user = message_forwarder.get_userid_for_user_reply_thread(mes)
+        if thread_user is not None:
+            userid = thread_user
+        else:
+            # Otherwise send an error
+            await mes.channel.send(f"I wasn't able to find a user anywhere based on that message. `{CMD_PREFIX}search USER` or `{CMD_PREFIX}search` in a reply thread")
+            return
 
     output = await search_helper(userid)
     await commonbot.utils.send_message(output, mes.channel)

--- a/src/main.py
+++ b/src/main.py
@@ -45,7 +45,7 @@ FUNC_DICT = {
     "reply":       [commands.reply,                frwrdr],
     "say":         [commands.say,                  None],
     "scam":        [commands.log_user,             LogTypes.SCAM],
-    "search":      [commands.search_command,       None],
+    "search":      [commands.search_command,       frwrdr],
     "sync":        [commands.sync,                 None],
     "unban":       [commands.log_user,             LogTypes.UNBAN],
     "unblock":     [commands.block_user,           False],


### PR DESCRIPTION
## Summary

Staff can now use plain `$search` in reply threads and they'll get notes for the user the thread is for.

Previous behavior of using a mention still works.

## Testing

* In a reply thread:
![image](https://user-images.githubusercontent.com/21993469/223891387-66060809-aca2-4919-9ce2-3dfccff2fdf8.png)

* In another channel:
![image](https://user-images.githubusercontent.com/21993469/223891526-7f2a0f18-6c1c-4337-89d0-7d40aeb13480.png)
