### PR TITLE
commands: allow omitting user reference in reply threads

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from commonbot.timekeep import Timekeeper
 
 # Needs to happen before other imports that cause db to be queried
 import db
+
 db.initialize()
 
 import commands
@@ -19,17 +20,16 @@ import config
 import visualize
 from client import client
 from config import LogTypes, USERID_LOG_PATH
+from forwarder import message_forwarder
 from spam import Spammers
 from waiting import AnsweringMachineEntry, is_in_home_server
 from watcher import Watcher
-from forwarder import MessageForwarder
 
 # Initialize helper classes
 dbg = Debug(config.OWNER, config.CMD_PREFIX, config.DEBUG_BOT)
 spam = Spammers()
 tk = Timekeeper()
 watch = Watcher()
-frwrdr = MessageForwarder(config.MAILBOX, config.HOME_SERVER, config.THREAD_ROLES)
 
 FUNC_DICT = {
     "ban":         [commands.log_user,             LogTypes.BAN],
@@ -42,10 +42,10 @@ FUNC_DICT = {
     "note":        [commands.log_user,             LogTypes.NOTE],
     "preview":     [commands.preview,              None],
     "remove":      [commands.remove_error,         False],
-    "reply":       [commands.reply,                frwrdr],
+    "reply":       [commands.reply,                None],
     "say":         [commands.say,                  None],
     "scam":        [commands.log_user,             LogTypes.SCAM],
-    "search":      [commands.search_command,       frwrdr],
+    "search":      [commands.search_command,       None],
     "sync":        [commands.sync,                 None],
     "unban":       [commands.log_user,             LogTypes.UNBAN],
     "unblock":     [commands.block_user,           False],
@@ -348,7 +348,7 @@ async def on_message(message: discord.Message):
 
         # If bouncer detects a private DM sent to it, forward it to staff
         if isinstance(message.channel, discord.channel.DMChannel):
-            await frwrdr.on_dm(message)
+            await message_forwarder.on_dm(message)
             return
 
         spam_message = await spam.check_spammer(message)

--- a/src/spam.py
+++ b/src/spam.py
@@ -9,6 +9,8 @@ from commonbot.utils import check_roles
 from client import client
 from config import SPAM_CHAN, VALID_ROLES, IGNORE_SPAM
 
+from utils import get_userid
+
 SPAM_MES_THRESHOLD = 5
 URL_REGEX = r"https?:\/\/.+\..+"
 NORMAL_TIMEOUT_MIN = 10
@@ -104,9 +106,8 @@ class Spammers:
                 pass
 
     async def unmute(self, message: discord.Message, _):
-        uid = ul.parse_id(message)
+        uid, _ = await get_userid(ul, message, "unmute")
         if not uid:
-            await message.channel.send("I wasn't able to find a user in that message")
             return
 
         if not message.guild:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,41 @@
+import discord
+
+from config import CMD_PREFIX
+from forwarder import message_forwarder
+
+from commonbot.user import UserLookup
+
+
+async def get_userid(ul: UserLookup, mes: discord.Message, cmd: str, args: str = "") -> (int | None, bool):
+    """
+    Retrieves the user referenced in the given message.
+
+    Uses an explicit user mention if available, otherwise uses the reply thread user if the command
+    is in a reply thread.
+
+    The second return value is useful in case the message needs to be stripped to access the args -
+    it indicates how many words to strip:
+     - True -> the user came from the message, strip two words (the command, and user reference)
+     - False -> the user came from the reply thread, strip one word (the command)
+
+    :param mes: Message to check.
+    :param cmd: Command name for help output, if no user is found.
+    :param args: Command args for help output, if no user is found.
+    :return: The user id (or None if found), and whether the user came from the message (as opposed to from the reply thread).
+    """
+    # First check message
+    userid = ul.parse_id(mes)
+    if userid:
+        return userid, True
+
+    # If no user in the message, check if it's a reply thread
+    thread_user = message_forwarder.get_userid_for_user_reply_thread(mes)
+    if thread_user is not None:
+        return thread_user, False
+
+    outside_reply_thread = f"{CMD_PREFIX}{cmd} USER {args}".strip()
+    inside_reply_thread = f"{CMD_PREFIX}{cmd} {args}".strip()
+
+    # Otherwise send an error
+    await mes.channel.send(f"I wasn't able to find a user anywhere based on that message. `{outside_reply_thread}` or `{inside_reply_thread}` in a reply thread")
+    return None, False

--- a/src/watcher.py
+++ b/src/watcher.py
@@ -4,6 +4,8 @@ from commonbot.user import UserLookup
 
 import db
 from client import client
+from utils import get_userid
+
 
 class Watcher:
     def __init__(self):
@@ -19,9 +21,8 @@ class Watcher:
             self.watchlist.remove(id)
 
     async def watch_user(self, mes: discord.Message, _):
-        userid = self.ul.parse_id(mes)
+        userid, _ = await get_userid(self.ul, mes, "watch")
         if not userid:
-            await mes.channel.send("I was unable to find a user in that message")
             return
 
         db.add_watch(userid)
@@ -31,9 +32,8 @@ class Watcher:
         await mes.channel.send(f"{username} has been added to the watch list. :spy:")
 
     async def unwatch_user(self, mes: discord.Message, _):
-        userid = self.ul.parse_id(mes)
+        userid, _ = await get_userid(self.ul, mes, "unwatch")
         if not userid:
-            await mes.channel.send("I was unable to find a user in that message")
             return
         elif userid not in self.watchlist:
             await mes.channel.send("...That user is not being watched")


### PR DESCRIPTION
## Summary

These changes are to support using the reply thread user in reply threads rather than needing to ping the user in bouncer commands.

Pinging a user will still work as before, if desired.

They depend on this PR to the commonbot library: https://github.com/aquova/commonbot/pull/1

Please approve/merge that one first, or let me know if you have a different approach.

---

Overall, the idea is that in a reply thread we have a user reference that staff is probably going to want to use in commands: the user the reply thread is for.

Commands always looked like
```
$command USER <ARGS>
```

but now they can look like
```
$command <ARGS>
```

Right now that only works for `$reply`, and I just added it for `$search`, but it's probably applicable for every command.

This PR makes it work for every command.

To support that, the changes are:
* Pass the message forwarder in to each command through a global variable, rather than one by one
   * This is pretty hacky I think, LMK if you know a better method.
* Create a common helper function which firsts checks the message for a user reference, then checks the reply thread.
  * It returns the user id and whether the user id came from the message, to know whether the user id needs to be stripped later for commands that have more arguments.
* Use that helper function everywhere a user id is parsed.

Let me know if you'd like any changes!

## Testing

* I ran every command this affects inside and outside a reply thread, and they looked fine.